### PR TITLE
GF-sync part.1

### DIFF
--- a/src/main/java/us/dontcareabout/PickRed/server/gf/SessionClub.java
+++ b/src/main/java/us/dontcareabout/PickRed/server/gf/SessionClub.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.servlet.ServletContext;
 import javax.servlet.annotation.WebListener;
 import javax.servlet.http.HttpSessionEvent;
 import javax.servlet.http.HttpSessionListener;
@@ -15,6 +16,10 @@ import javax.servlet.http.HttpSessionListener;
  */
 @WebListener
 public class SessionClub implements HttpSessionListener {
+	public static final String ATTRIBUTE_NAME = "GF:SessionClub";
+
+	/** 是否已經塞進 {@link ServletContext} 的 flag */
+	private boolean injectContext;
 	private HashMap<String, Set<String>> clubMap = new HashMap<>();
 	private HashMap<String, Set<String>> sessionMap = new HashMap<>();
 
@@ -83,7 +88,15 @@ public class SessionClub implements HttpSessionListener {
 	}
 
 	@Override
-	public void sessionCreated(HttpSessionEvent event) {}
+	public void sessionCreated(HttpSessionEvent event) {
+		//TODO 改用 Spring 解決？
+		//由於 instance 是由 JSP Container 建立的
+		//所以必須塞進 ServletContext 當中，這樣其他地方才能拿來用
+		if (injectContext) { return; }
+
+		event.getSession().getServletContext().setAttribute(ATTRIBUTE_NAME, this);
+		injectContext = true;
+	}
 
 	@Override
 	public void sessionDestroyed(HttpSessionEvent event) {

--- a/src/main/java/us/dontcareabout/PickRed/server/gf/SessionClub.java
+++ b/src/main/java/us/dontcareabout/PickRed/server/gf/SessionClub.java
@@ -5,11 +5,16 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.servlet.annotation.WebListener;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
+
 //Refactory GF
 /**
  * 處理 session 的社團參與狀況 XD。
  */
-public class SessionClub {
+@WebListener
+public class SessionClub implements HttpSessionListener {
 	private HashMap<String, Set<String>> clubMap = new HashMap<>();
 	private HashMap<String, Set<String>> sessionMap = new HashMap<>();
 
@@ -40,7 +45,19 @@ public class SessionClub {
 	}
 
 	public void close(String club) {
+		for (String session : sessionSet(club)) {
+			clubSet(session).remove(club);
+		}
+
 		clubMap.remove(club);
+	}
+
+	public void dead(String session) {
+		for (String club : clubSet(session)) {
+			sessionSet(club).remove(session);
+		}
+
+		clubMap.remove(session);
 	}
 
 	public Set<String> sessionSet(String id) {
@@ -63,5 +80,13 @@ public class SessionClub {
 		}
 
 		return result;
+	}
+
+	@Override
+	public void sessionCreated(HttpSessionEvent event) {}
+
+	@Override
+	public void sessionDestroyed(HttpSessionEvent event) {
+		dead(event.getSession().getId());
 	}
 }

--- a/src/main/java/us/dontcareabout/PickRed/server/gf/SessionClub.java
+++ b/src/main/java/us/dontcareabout/PickRed/server/gf/SessionClub.java
@@ -62,7 +62,7 @@ public class SessionClub implements HttpSessionListener {
 			sessionSet(club).remove(session);
 		}
 
-		clubMap.remove(session);
+		sessionMap.remove(session);
 	}
 
 	public Set<String> sessionSet(String id) {

--- a/src/main/java/us/dontcareabout/PickRed/server/gf/SessionClub.java
+++ b/src/main/java/us/dontcareabout/PickRed/server/gf/SessionClub.java
@@ -1,0 +1,67 @@
+package us.dontcareabout.PickRed.server.gf;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+//Refactory GF
+/**
+ * 處理 session 的社團參與狀況 XD。
+ */
+public class SessionClub {
+	private HashMap<String, Set<String>> clubMap = new HashMap<>();
+	private HashMap<String, Set<String>> sessionMap = new HashMap<>();
+
+	public void join(String club, String session) {
+		sessionSet(club).add(session);
+		clubSet(session).add(club);
+	}
+
+	public void join(String club, List<String> sessionList) {
+		sessionSet(club).addAll(sessionList);
+
+		for (String session : sessionList) {
+			clubSet(session).add(club);
+		}
+	}
+
+	public void leave(String club, String session) {
+		sessionSet(club).remove(session);
+		clubSet(session).remove(club);
+	}
+
+	public void leave(String club, List<String> sessionList) {
+		sessionSet(club).removeAll(sessionList);
+
+		for (String session : sessionList) {
+			clubSet(session).remove(club);
+		}
+	}
+
+	public void close(String club) {
+		clubMap.remove(club);
+	}
+
+	public Set<String> sessionSet(String id) {
+		Set<String> result = clubMap.get(id);
+
+		if (result == null) {
+			result = new HashSet<>();
+			clubMap.put(id, result);
+		}
+
+		return result;
+	}
+
+	public Set<String> clubSet(String session) {
+		Set<String> result = sessionMap.get(session);
+
+		if (result == null) {
+			result = new HashSet<>();
+			sessionMap.put(session, result);
+		}
+
+		return result;
+	}
+}


### PR DESCRIPTION
@cwchou2016

故事是這樣的：web server 原本的設計是無法認得 client 的，這會造成很多問題，所以後來最常見的解法是 web server 透過 session 這個機制去分辨 client。你這裡可以先把 session 視為 client 的身份證 or 等意詞。

在後續的情節（？）中，我們會需要知道某一個 session 加入哪些我稱之為 club 的 group 當中。用 PickRed 來舉例：系統同時會有很多桌（房間）在玩各自的牌局。我們必須得知道哪些桌裡頭有哪些人，這樣才能對那些 client 傳特定的資料。所以對於 PickRed 而言，每開一桌，就會給這一桌取個社團名字，然後把那一桌的 client 都加入社團。

這可以應用的範圍還會更廣一些，所以取名會是中性、好理解的 club 而不是 table / room。然後是在 PickRed 作 POC，事成之後會重整搬到 [GF](https://github.com/DontCareAbout/GF) 中。